### PR TITLE
Add ThemeParkPlayground SpriteKit project scaffold

### DIFF
--- a/ThemeParkPlayground/AppDelegate.swift
+++ b/ThemeParkPlayground/AppDelegate.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let viewController = GameViewController()
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        self.window = window
+        return true
+    }
+}

--- a/ThemeParkPlayground/BottleTossScene.swift
+++ b/ThemeParkPlayground/BottleTossScene.swift
@@ -1,0 +1,272 @@
+import SpriteKit
+
+class BottleTossScene: SKScene, SKPhysicsContactDelegate {
+    private let backButton = ButtonNode(size: CGSize(width: 160, height: 44), text: "Back to Park", color: .systemRed)
+    private let playAgainButton = ButtonNode(size: CGSize(width: 160, height: 44), text: "Play Again", color: .systemGreen)
+    private let overlayNode = SKSpriteNode(color: SKColor(white: 0, alpha: 0.65), size: CGSize(width: 280, height: 180))
+    private let hudTicketsLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private var bottles: [SKSpriteNode] = []
+    private var downedBottles: Set<SKSpriteNode> = []
+    private var currentBall: SKShapeNode?
+    private var touchStartLocation: CGPoint?
+    private var ballsRemaining = 3
+    private var roundActive = true
+    private let resultLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 0.1, green: 0.15, blue: 0.18, alpha: 1)
+        physicsWorld.gravity = CGVector(dx: 0, dy: -12)
+        physicsWorld.contactDelegate = self
+        setupHUD()
+        setupLane()
+        spawnBottleStack()
+        spawnNextBall()
+    }
+
+    private func setupHUD() {
+        camera = SKCameraNode()
+        if let camera = camera {
+            addChild(camera)
+            camera.addChild(backButton)
+            camera.addChild(hudTicketsLabel)
+            camera.addChild(overlayNode)
+        }
+
+        backButton.position = CGPoint(x: -size.width / 2 + 110, y: size.height / 2 - 50)
+
+        hudTicketsLabel.fontSize = 18
+        hudTicketsLabel.fontColor = .white
+        hudTicketsLabel.horizontalAlignmentMode = .right
+        hudTicketsLabel.verticalAlignmentMode = .top
+        hudTicketsLabel.position = CGPoint(x: size.width / 2 - 16, y: size.height / 2 - 20)
+        updateTicketsLabel()
+
+        overlayNode.isHidden = true
+        overlayNode.zPosition = 50
+        overlayNode.position = CGPoint(x: 0, y: 60)
+
+        resultLabel.fontSize = 20
+        resultLabel.verticalAlignmentMode = .center
+        resultLabel.numberOfLines = 2
+        resultLabel.preferredMaxLayoutWidth = 240
+        overlayNode.addChild(resultLabel)
+
+        playAgainButton.position = CGPoint(x: 0, y: -50)
+        overlayNode.addChild(playAgainButton)
+
+        let overlayBack = ButtonNode(size: CGSize(width: 160, height: 44), text: "Back", color: .systemBlue)
+        overlayBack.position = CGPoint(x: 0, y: -100)
+        overlayBack.name = "overlayBack"
+        overlayNode.addChild(overlayBack)
+    }
+
+    private func setupLane() {
+        let lane = SKSpriteNode(color: .darkGray, size: CGSize(width: size.width, height: 200))
+        lane.position = CGPoint(x: size.width / 2, y: 100)
+        lane.zPosition = -1
+        addChild(lane)
+
+        let ground = SKNode()
+        ground.position = CGPoint(x: size.width / 2, y: 80)
+        ground.physicsBody = SKPhysicsBody(edgeFrom: CGPoint(x: -size.width / 2, y: 0), to: CGPoint(x: size.width / 2, y: 0))
+        ground.physicsBody?.categoryBitMask = PhysicsCategory.walls
+        ground.physicsBody?.contactTestBitMask = PhysicsCategory.projectiles
+        addChild(ground)
+    }
+
+    private func spawnBottleStack() {
+        for node in bottles { node.removeFromParent() }
+        bottles.removeAll()
+        downedBottles.removeAll()
+
+        let baseWidth: CGFloat = 40
+        let baseHeight: CGFloat = 80
+        let spacing: CGFloat = 8
+        let rows: [[CGFloat]] = [[-1, 0, 1], [-0.5, 0.5], [0]]
+        for (index, row) in rows.enumerated() {
+            let y = 200 + CGFloat(index) * (baseHeight + spacing)
+            for offset in row {
+                let bottle = SKSpriteNode(color: .lightGray, size: CGSize(width: baseWidth, height: baseHeight))
+                bottle.position = CGPoint(x: size.width / 2 + offset * (baseWidth + spacing), y: y)
+                bottle.physicsBody = SKPhysicsBody(rectangleOf: bottle.size)
+                bottle.physicsBody?.allowsRotation = true
+                bottle.physicsBody?.restitution = 0.2
+                bottle.physicsBody?.friction = 0.8
+                bottle.physicsBody?.mass = 0.4
+                bottle.physicsBody?.categoryBitMask = PhysicsCategory.bottles
+                bottle.physicsBody?.contactTestBitMask = PhysicsCategory.projectiles
+                bottle.physicsBody?.collisionBitMask = PhysicsCategory.projectiles | PhysicsCategory.bottles | PhysicsCategory.walls
+                bottle.name = "bottle"
+                addChild(bottle)
+                bottles.append(bottle)
+            }
+        }
+    }
+
+    private func spawnNextBall() {
+        guard ballsRemaining > 0 else { return }
+        let ball = SKShapeNode(circleOfRadius: 18)
+        ball.fillColor = .systemTeal
+        ball.strokeColor = .white
+        ball.position = CGPoint(x: size.width / 2, y: 110)
+        ball.zPosition = 5
+        let body = SKPhysicsBody(circleOfRadius: 18)
+        body.categoryBitMask = PhysicsCategory.projectiles
+        body.contactTestBitMask = PhysicsCategory.bottles | PhysicsCategory.walls
+        body.collisionBitMask = PhysicsCategory.bottles | PhysicsCategory.walls
+        body.restitution = 0.4
+        body.friction = 0.2
+        body.mass = 0.6
+        ball.physicsBody = body
+        ball.physicsBody?.isDynamic = false
+        addChild(ball)
+        currentBall = ball
+        touchStartLocation = nil
+    }
+
+    private func updateTicketsLabel() {
+        hudTicketsLabel.text = "Tickets: \(TicketStore.tickets)"
+    }
+
+    private func checkRoundStatus() {
+        for bottle in bottles where !downedBottles.contains(bottle) {
+            if abs(bottle.zRotation) > .pi / 6 || bottle.position.y < 180 {
+                downedBottles.insert(bottle)
+            }
+        }
+
+        if downedBottles.count == bottles.count {
+            endRound(won: true)
+        } else if ballsRemaining == 0 && currentBall == nil {
+            endRound(won: false)
+        }
+    }
+
+    private func endRound(won: Bool) {
+        guard roundActive else { return }
+        roundActive = false
+        overlayNode.isHidden = false
+        overlayNode.alpha = 0
+        overlayNode.run(SKAction.fadeIn(withDuration: 0.25))
+
+        if won {
+            TicketStore.addTickets(2)
+            updateTicketsLabel()
+            resultLabel.text = "You win!\n+2 tickets"
+        } else {
+            resultLabel.text = "Try again!"
+        }
+    }
+
+    private func resetRound() {
+        roundActive = true
+        ballsRemaining = 3
+        currentBall?.removeFromParent()
+        currentBall = nil
+        spawnBottleStack()
+        spawnNextBall()
+    }
+
+    private func handleBackToPark() {
+        guard let view = view else { return }
+        let scene = ParkScene(size: size)
+        view.transition(to: scene)
+    }
+
+    private func handlePlayAgain() {
+        overlayNode.isHidden = true
+        resultLabel.text = ""
+        resetRound()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        if !overlayNode.isHidden {
+            let location = touch.location(in: overlayNode)
+            if playAgainButton.contains(location) {
+                playAgainButton.colorBlendFactor = 0.4
+            } else if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode, backNode.contains(location) {
+                backNode.colorBlendFactor = 0.4
+            }
+            return
+        }
+
+        let cameraLocation = touch.location(in: camera ?? self)
+        if backButton.contains(cameraLocation) {
+            backButton.colorBlendFactor = 0.4
+            return
+        }
+
+        guard let ball = currentBall, ball.contains(touch.location(in: self)) else { return }
+        touchStartLocation = touch.location(in: self)
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard overlayNode.isHidden, let touch = touches.first, let ball = currentBall, let start = touchStartLocation else { return }
+        let location = touch.location(in: self)
+        let dx = location.x - start.x
+        let dy = location.y - start.y
+        let clampedY = max(90, min(200, start.y + dy))
+        ball.position = CGPoint(x: start.x + dx, y: clampedY)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        if !overlayNode.isHidden {
+            let location = touch.location(in: overlayNode)
+            if playAgainButton.contains(location) {
+                playAgainButton.colorBlendFactor = 0
+                handlePlayAgain()
+                return
+            }
+            if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode, backNode.contains(location) {
+                backNode.colorBlendFactor = 0
+                handleBackToPark()
+                return
+            }
+            playAgainButton.colorBlendFactor = 0
+            if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode {
+                backNode.colorBlendFactor = 0
+            }
+            return
+        }
+
+        let cameraLocation = touch.location(in: camera ?? self)
+        if backButton.contains(cameraLocation) {
+            backButton.colorBlendFactor = 0
+            handleBackToPark()
+            return
+        }
+
+        guard let ball = currentBall, let start = touchStartLocation else { return }
+        let releaseLocation = touch.location(in: self)
+        let dx = releaseLocation.x - start.x
+        let dy = releaseLocation.y - start.y
+        let impulse = CGVector(dx: dx * 0.6, dy: max(dy, 40) * 0.9)
+        ball.physicsBody?.isDynamic = true
+        ball.physicsBody?.applyImpulse(impulse)
+        ballsRemaining -= 1
+        currentBall = nil
+        touchStartLocation = nil
+        run(SKAction.wait(forDuration: 0.6)) { [weak self] in
+            self?.spawnNextBall()
+        }
+        checkRoundStatus()
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchesEnded(touches, with: event)
+    }
+
+    override func update(_ currentTime: TimeInterval) {
+        if roundActive { checkRoundStatus() }
+
+        enumerateChildNodes(withName: "//*") { node, _ in
+            if let shape = node as? SKShapeNode,
+               shape.physicsBody?.categoryBitMask == PhysicsCategory.projectiles,
+               shape.position.y < -100 {
+                shape.removeFromParent()
+            }
+        }
+    }
+}

--- a/ThemeParkPlayground/GameViewController.swift
+++ b/ThemeParkPlayground/GameViewController.swift
@@ -1,0 +1,20 @@
+import UIKit
+import SpriteKit
+
+class GameViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let skView = SKView(frame: view.bounds)
+        skView.ignoresSiblingOrder = true
+        view = skView
+
+        let scene = MainMenuScene(size: view.bounds.size)
+        scene.scaleMode = .resizeFill
+        skView.presentScene(scene)
+    }
+
+    override var prefersStatusBarHidden: Bool {
+        return true
+    }
+}

--- a/ThemeParkPlayground/MainMenuScene.swift
+++ b/ThemeParkPlayground/MainMenuScene.swift
@@ -1,0 +1,42 @@
+import SpriteKit
+
+class MainMenuScene: SKScene {
+    private var playButton: ButtonNode!
+
+    override func didMove(to view: SKView) {
+        backgroundColor = .black
+
+        let title = SKLabelNode(text: "ThemeParkPlayground")
+        title.fontName = "AvenirNext-Bold"
+        title.fontSize = 36
+        title.fontColor = .white
+        title.position = CGPoint(x: size.width / 2, y: size.height * 0.65)
+        addChild(title)
+
+        playButton = ButtonNode(size: CGSize(width: 180, height: 60), text: "Play", color: .systemGreen)
+        playButton.position = CGPoint(x: size.width / 2, y: size.height * 0.4)
+        addChild(playButton)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        if playButton.contains(location) {
+            playButton.colorBlendFactor = 0.4
+        }
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        playButton.colorBlendFactor = 0
+        guard let touch = touches.first else { return }
+        let location = touch.location(in: self)
+        if playButton.contains(location), let view = view {
+            let scene = ParkScene(size: size)
+            view.transition(to: scene)
+        }
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        playButton.colorBlendFactor = 0
+    }
+}

--- a/ThemeParkPlayground/ParkScene.swift
+++ b/ThemeParkPlayground/ParkScene.swift
@@ -1,0 +1,425 @@
+import SpriteKit
+
+class ParkScene: SKScene, SKPhysicsContactDelegate {
+    private let player = SKSpriteNode(color: .systemBlue, size: CGSize(width: 28, height: 28))
+    private var movementDirections: Set<Direction> = []
+    private var dpadButtons: [Direction: SKSpriteNode] = [:]
+    private var touchDirectionMap: [UITouch: Direction] = [:]
+    private let playerSpeed: CGFloat = 140
+    private var lastUpdateTime: TimeInterval = 0
+    private let cameraNode = SKCameraNode()
+    private let hudNode = SKNode()
+    private let hudTicketsLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private let backButton = ButtonNode(size: CGSize(width: 140, height: 44), text: "Back", color: .systemRed)
+    private var bottlePortal: SKSpriteNode!
+    private var plinkoPortal: SKSpriteNode!
+    private var coasterRide: SKSpriteNode!
+    private var rideVisited = false
+    private var rideAnimating = false
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(displayP3Red: 0.4, green: 0.75, blue: 0.4, alpha: 1)
+        physicsWorld.gravity = .zero
+        physicsWorld.contactDelegate = self
+
+        setupWorld()
+        setupPlayer()
+        setupCamera()
+        setupHUD()
+        setupDPad()
+        updateTicketsLabel()
+
+        view.isMultipleTouchEnabled = true
+    }
+
+    private func setupWorld() {
+        let ground = SKSpriteNode(color: .init(red: 0.5, green: 0.85, blue: 0.5, alpha: 1), size: CGSize(width: 2000, height: 2000))
+        ground.zPosition = -20
+        addChild(ground)
+
+        // Paths (placeholder art)
+        for offset in stride(from: -400, through: 400, by: 200) {
+            let path = SKSpriteNode(color: .brown, size: CGSize(width: 1200, height: 60))
+            path.position = CGPoint(x: 0, y: CGFloat(offset))
+            path.zPosition = -10
+            addChild(path)
+        }
+
+        // Fences / walls
+        let fenceSize = CGSize(width: 1400, height: 40)
+        let bottomFence = SKSpriteNode(color: .darkGray, size: fenceSize)
+        bottomFence.position = CGPoint(x: 0, y: -500)
+        configureFence(bottomFence)
+
+        let topFence = bottomFence.copy() as! SKSpriteNode
+        topFence.position = CGPoint(x: 0, y: 500)
+        configureFence(topFence)
+
+        let leftFence = SKSpriteNode(color: .darkGray, size: CGSize(width: 40, height: 1000))
+        leftFence.position = CGPoint(x: -650, y: 0)
+        configureFence(leftFence)
+
+        let rightFence = leftFence.copy() as! SKSpriteNode
+        rightFence.position = CGPoint(x: 650, y: 0)
+        configureFence(rightFence)
+
+        // Bottle Toss portal pad
+        bottlePortal = createPortal(color: .systemYellow, text: "🎯 Bottle Toss")
+        bottlePortal.position = CGPoint(x: -250, y: 150)
+        addChild(bottlePortal)
+
+        // Plinko portal pad
+        plinkoPortal = createPortal(color: .systemPurple, text: "🟣 Plinko")
+        plinkoPortal.position = CGPoint(x: 250, y: 150)
+        addChild(plinkoPortal)
+
+        // Roller coaster ride pad
+        coasterRide = SKSpriteNode(color: .systemRed, size: CGSize(width: 180, height: 90))
+        coasterRide.name = "coaster"
+        coasterRide.position = CGPoint(x: 0, y: -100)
+        coasterRide.zPosition = 1
+        coasterRide.physicsBody = SKPhysicsBody(rectangleOf: coasterRide.size)
+        coasterRide.physicsBody?.isDynamic = false
+        coasterRide.physicsBody?.categoryBitMask = PhysicsCategory.ridePads
+        coasterRide.physicsBody?.collisionBitMask = 0
+        coasterRide.physicsBody?.contactTestBitMask = PhysicsCategory.player
+        addChild(coasterRide)
+
+        let rideLabel = SKLabelNode(text: "🎢 Roller Coaster")
+        rideLabel.fontName = "AvenirNext-Bold"
+        rideLabel.fontSize = 18
+        rideLabel.fontColor = .white
+        rideLabel.position = CGPoint(x: 0, y: 0)
+        rideLabel.zPosition = 2
+        coasterRide.addChild(rideLabel)
+
+        // Ferris wheel decoration (placeholder art)
+        createFerrisWheel(at: CGPoint(x: -400, y: -200))
+    }
+
+    private func configureFence(_ node: SKSpriteNode) {
+        node.zPosition = 5
+        node.physicsBody = SKPhysicsBody(rectangleOf: node.size)
+        node.physicsBody?.isDynamic = false
+        node.physicsBody?.categoryBitMask = PhysicsCategory.walls
+        node.physicsBody?.collisionBitMask = PhysicsCategory.player
+        node.physicsBody?.contactTestBitMask = PhysicsCategory.none
+        addChild(node)
+    }
+
+    private func createPortalLabel(text: String) -> SKLabelNode {
+        let label = SKLabelNode(text: text)
+        label.fontName = "AvenirNext-DemiBold"
+        label.fontSize = 16
+        label.fontColor = .black
+        label.verticalAlignmentMode = .center
+        label.zPosition = 2
+        return label
+    }
+
+    private func createPortal(color: SKColor, text: String) -> SKSpriteNode {
+        let pad = SKSpriteNode(color: color, size: CGSize(width: 200, height: 80))
+        pad.zPosition = 1
+        pad.physicsBody = SKPhysicsBody(rectangleOf: pad.size)
+        pad.physicsBody?.isDynamic = false
+        pad.physicsBody?.categoryBitMask = PhysicsCategory.portalPads
+        pad.physicsBody?.collisionBitMask = 0
+        pad.physicsBody?.contactTestBitMask = PhysicsCategory.player
+        let label = createPortalLabel(text: text)
+        pad.addChild(label)
+        return pad
+    }
+
+    private func createFerrisWheel(at position: CGPoint) {
+        let wheelRadius: CGFloat = 80
+        let circle = SKShapeNode(circleOfRadius: wheelRadius)
+        circle.strokeColor = .white
+        circle.lineWidth = 4
+        circle.position = position
+        circle.zPosition = 1
+        addChild(circle)
+
+        let hub = SKShapeNode(circleOfRadius: 10)
+        hub.fillColor = .systemOrange
+        hub.strokeColor = .clear
+        hub.position = position
+        hub.zPosition = 2
+        addChild(hub)
+
+        let spokes = SKNode()
+        spokes.position = position
+        spokes.zPosition = 1
+        addChild(spokes)
+
+        for i in 0..<6 {
+            let spoke = SKShapeNode(rectOf: CGSize(width: 6, height: wheelRadius * 2))
+            spoke.fillColor = .lightGray
+            spoke.strokeColor = .clear
+            spoke.zPosition = 1
+            spoke.zRotation = CGFloat(i) * (.pi / 6)
+            spokes.addChild(spoke)
+        }
+
+        let cabins = SKNode()
+        cabins.position = position
+        cabins.zPosition = 2
+        addChild(cabins)
+
+        for angle in stride(from: 0.0, to: Double.pi * 2, by: Double.pi / 3) {
+            let cabin = SKShapeNode(rectOf: CGSize(width: 18, height: 18), cornerRadius: 4)
+            cabin.fillColor = .systemBlue
+            cabin.strokeColor = .clear
+            cabin.position = CGPoint(x: position.x + wheelRadius * cos(angle),
+                                     y: position.y + wheelRadius * sin(angle))
+            cabins.addChild(cabin)
+        }
+
+        let rotation = SKAction.repeatForever(SKAction.rotate(byAngle: .pi, duration: 6))
+        spokes.run(rotation)
+        cabins.run(rotation)
+    }
+
+    private func setupPlayer() {
+        player.position = CGPoint(x: 0, y: 0)
+        player.zPosition = 10
+        player.physicsBody = SKPhysicsBody(rectangleOf: player.size)
+        player.physicsBody?.allowsRotation = false
+        player.physicsBody?.linearDamping = 3
+        player.physicsBody?.friction = 0
+        player.physicsBody?.categoryBitMask = PhysicsCategory.player
+        player.physicsBody?.collisionBitMask = PhysicsCategory.walls
+        player.physicsBody?.contactTestBitMask = PhysicsCategory.portalPads | PhysicsCategory.ridePads
+        addChild(player)
+    }
+
+    private func setupCamera() {
+        camera = cameraNode
+        addChild(cameraNode)
+        cameraNode.position = player.position
+        cameraNode.addChild(hudNode)
+        hudNode.zPosition = 100
+    }
+
+    private func setupHUD() {
+        hudTicketsLabel.fontSize = 18
+        hudTicketsLabel.horizontalAlignmentMode = .right
+        hudTicketsLabel.verticalAlignmentMode = .top
+        hudTicketsLabel.fontColor = .white
+        hudTicketsLabel.position = CGPoint(x: size.width / 2 - 16, y: size.height / 2 - 20)
+        hudNode.addChild(hudTicketsLabel)
+
+        backButton.position = CGPoint(x: -size.width / 2 + 100, y: size.height / 2 - 40)
+        backButton.zPosition = 101
+        hudNode.addChild(backButton)
+    }
+
+    private func setupDPad() {
+        let dpadSize: CGFloat = 60
+        let positions: [Direction: CGPoint] = [
+            .up: CGPoint(x: -size.width / 2 + dpadSize, y: -size.height / 2 + dpadSize * 2.3),
+            .down: CGPoint(x: -size.width / 2 + dpadSize, y: -size.height / 2 + dpadSize * 0.7),
+            .left: CGPoint(x: -size.width / 2 + dpadSize - 50, y: -size.height / 2 + dpadSize * 1.5),
+            .right: CGPoint(x: -size.width / 2 + dpadSize + 50, y: -size.height / 2 + dpadSize * 1.5)
+        ]
+
+        for (direction, position) in positions {
+            let node = SKSpriteNode(color: .darkGray, size: CGSize(width: 54, height: 54))
+            node.alpha = 0.8
+            node.position = position
+            node.name = "dpad_\(direction)"
+            hudNode.addChild(node)
+            dpadButtons[direction] = node
+        }
+    }
+
+    private func updateTicketsLabel() {
+        hudTicketsLabel.text = "Tickets: \(TicketStore.tickets)"
+    }
+
+    private func updateVelocity() {
+        guard !movementDirections.isEmpty else {
+            player.physicsBody?.velocity = .zero
+            return
+        }
+        var dx: CGFloat = 0
+        var dy: CGFloat = 0
+        for direction in movementDirections {
+            dx += direction.vector.dx
+            dy += direction.vector.dy
+        }
+        let vector = CGVector(dx: dx, dy: dy)
+        let length = sqrt(vector.dx * vector.dx + vector.dy * vector.dy)
+        let normalized = length > 0 ? CGVector(dx: vector.dx / length, dy: vector.dy / length) : .zero
+        player.physicsBody?.velocity = CGVector(dx: normalized.dx * playerSpeed, dy: normalized.dy * playerSpeed)
+    }
+
+    private func handleWorldTap(at location: CGPoint) {
+        guard !rideAnimating else { return }
+        if player.frame.intersects(coasterRide.frame) {
+            triggerCoasterRide()
+            return
+        }
+        if player.frame.intersects(bottlePortal.frame) {
+            goToBottleToss()
+            return
+        }
+        if player.frame.intersects(plinkoPortal.frame) {
+            goToPlinko()
+            return
+        }
+    }
+
+    private func triggerCoasterRide() {
+        guard !rideAnimating else { return }
+        rideAnimating = true
+        movementDirections.removeAll()
+        updateVelocity()
+
+        let woo = SKLabelNode(text: "Woo!")
+        woo.fontName = "AvenirNext-Bold"
+        woo.fontColor = .white
+        woo.fontSize = 32
+        woo.position = CGPoint(x: 0, y: 40)
+        woo.alpha = 0
+        cameraNode.addChild(woo)
+
+        let focusPosition = coasterRide.position
+        let focusAction = SKAction.move(to: focusPosition, duration: 0.4)
+        focusAction.timingMode = .easeInEaseOut
+
+        let sequence = SKAction.sequence([
+            SKAction.run { woo.run(SKAction.fadeIn(withDuration: 0.1)) },
+            focusAction,
+            SKAction.run { [weak self] in self?.cameraShake() },
+            SKAction.wait(forDuration: 0.5),
+            SKAction.run { woo.run(SKAction.sequence([SKAction.wait(forDuration: 0.2), SKAction.fadeOut(withDuration: 0.2), SKAction.removeFromParent()])) }
+        ])
+
+        cameraNode.run(sequence) { [weak self] in
+            guard let self = self else { return }
+            self.rideAnimating = false
+            self.cameraNode.position = self.player.position
+            if !self.rideVisited {
+                self.rideVisited = true
+                TicketStore.addTickets(1)
+                self.updateTicketsLabel()
+            }
+        }
+    }
+
+    private func goToBottleToss() {
+        guard let view = view else { return }
+        let scene = BottleTossScene(size: size)
+        view.transition(to: scene)
+    }
+
+    private func goToPlinko() {
+        guard let view = view else { return }
+        let scene = PlinkoScene(size: size)
+        view.transition(to: scene)
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        for touch in touches {
+            let cameraLocation = touch.location(in: hudNode)
+            var handled = false
+            for (direction, button) in dpadButtons where button.contains(cameraLocation) {
+                button.colorBlendFactor = 0.6
+                movementDirections.insert(direction)
+                touchDirectionMap[touch] = direction
+                handled = true
+                updateVelocity()
+                break
+            }
+            if handled { continue }
+
+            if backButton.contains(cameraLocation) {
+                backButton.colorBlendFactor = 0.4
+            } else {
+                let worldLocation = touch.location(in: self)
+                handleWorldTap(at: worldLocation)
+            }
+        }
+    }
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        for touch in touches {
+            if let direction = touchDirectionMap[touch], let button = dpadButtons[direction] {
+                let cameraLocation = touch.location(in: hudNode)
+                if button.contains(cameraLocation) {
+                    button.colorBlendFactor = 0.6
+                } else {
+                    button.colorBlendFactor = 0
+                    movementDirections.remove(direction)
+                    touchDirectionMap.removeValue(forKey: touch)
+                    updateVelocity()
+                }
+            }
+        }
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        handleTouchCompletion(touches)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        handleTouchCompletion(touches)
+    }
+
+    private func handleTouchCompletion(_ touches: Set<UITouch>) {
+        for touch in touches {
+            if let direction = touchDirectionMap.removeValue(forKey: touch), let button = dpadButtons[direction] {
+                button.colorBlendFactor = 0
+                movementDirections.remove(direction)
+            } else {
+                let cameraLocation = touch.location(in: hudNode)
+                if backButton.contains(cameraLocation) {
+                    backButton.colorBlendFactor = 0
+                    if let view = view {
+                        let scene = MainMenuScene(size: size)
+                        view.transition(to: scene)
+                    }
+                }
+            }
+        }
+        updateVelocity()
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        var updated = false
+        for press in presses {
+            guard let key = press.key?.charactersIgnoringModifiers.lowercased() else { continue }
+            switch key {
+            case "w": movementDirections.insert(.up); updated = true
+            case "s": movementDirections.insert(.down); updated = true
+            case "a": movementDirections.insert(.left); updated = true
+            case "d": movementDirections.insert(.right); updated = true
+            default: break
+            }
+        }
+        if updated { updateVelocity() }
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        var updated = false
+        for press in presses {
+            guard let key = press.key?.charactersIgnoringModifiers.lowercased() else { continue }
+            switch key {
+            case "w": movementDirections.remove(.up); updated = true
+            case "s": movementDirections.remove(.down); updated = true
+            case "a": movementDirections.remove(.left); updated = true
+            case "d": movementDirections.remove(.right); updated = true
+            default: break
+            }
+        }
+        if updated { updateVelocity() }
+    }
+
+    override func update(_ currentTime: TimeInterval) {
+        if lastUpdateTime == 0 { lastUpdateTime = currentTime }
+        lastUpdateTime = currentTime
+        if !rideAnimating {
+            cameraNode.position = player.position
+        }
+    }
+}

--- a/ThemeParkPlayground/PlinkoScene.swift
+++ b/ThemeParkPlayground/PlinkoScene.swift
@@ -1,0 +1,301 @@
+import SpriteKit
+
+class PlinkoScene: SKScene, SKPhysicsContactDelegate {
+    private let backButton = ButtonNode(size: CGSize(width: 160, height: 44), text: "Back to Park", color: .systemRed)
+    private let playAgainButton = ButtonNode(size: CGSize(width: 160, height: 44), text: "Play Again", color: .systemGreen)
+    private let overlayNode = SKSpriteNode(color: SKColor(white: 0, alpha: 0.65), size: CGSize(width: 300, height: 200))
+    private let hudTicketsLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private var slotValues: [SKNode: Int] = [:]
+    private var ballsDropped = 0
+    private var activeBalls: Set<SKNode> = []
+    private let resultLabel = SKLabelNode(fontNamed: "AvenirNext-Bold")
+    private let maxBalls = 3
+
+    override func didMove(to view: SKView) {
+        backgroundColor = SKColor(red: 0.05, green: 0.08, blue: 0.12, alpha: 1)
+        physicsWorld.gravity = CGVector(dx: 0, dy: -9.8)
+        physicsWorld.contactDelegate = self
+        setupHUD()
+        setupBoard()
+    }
+
+    private func setupHUD() {
+        camera = SKCameraNode()
+        if let camera = camera {
+            addChild(camera)
+            camera.addChild(backButton)
+            camera.addChild(hudTicketsLabel)
+            camera.addChild(overlayNode)
+        }
+
+        backButton.position = CGPoint(x: -size.width / 2 + 110, y: size.height / 2 - 50)
+
+        hudTicketsLabel.fontSize = 18
+        hudTicketsLabel.fontColor = .white
+        hudTicketsLabel.horizontalAlignmentMode = .right
+        hudTicketsLabel.verticalAlignmentMode = .top
+        hudTicketsLabel.position = CGPoint(x: size.width / 2 - 16, y: size.height / 2 - 20)
+        updateTicketsLabel()
+
+        overlayNode.isHidden = true
+        overlayNode.zPosition = 50
+        overlayNode.position = CGPoint(x: 0, y: 60)
+
+        resultLabel.fontSize = 20
+        resultLabel.verticalAlignmentMode = .center
+        resultLabel.numberOfLines = 2
+        overlayNode.addChild(resultLabel)
+
+        playAgainButton.position = CGPoint(x: 0, y: -60)
+        overlayNode.addChild(playAgainButton)
+
+        let overlayBack = ButtonNode(size: CGSize(width: 160, height: 44), text: "Back", color: .systemBlue)
+        overlayBack.position = CGPoint(x: 0, y: -110)
+        overlayBack.name = "overlayBack"
+        overlayNode.addChild(overlayBack)
+    }
+
+    private func setupBoard() {
+        physicsBody = SKPhysicsBody(edgeLoopFrom: CGRect(x: 40, y: 60, width: size.width - 80, height: size.height - 120))
+        physicsBody?.categoryBitMask = PhysicsCategory.walls
+        physicsBody?.restitution = 0.2
+
+        addPegGrid()
+        addSlots()
+    }
+
+    private func addPegGrid() {
+        let columns = 7
+        let rows = 8
+        let spacingX = (size.width - 160) / CGFloat(columns - 1)
+        let spacingY: CGFloat = 70
+        let startY = size.height - 180
+        for row in 0..<rows {
+            for column in 0..<columns {
+                var x = CGFloat(column) * spacingX + 80
+                if row % 2 == 1 { x += spacingX / 2 }
+                let y = startY - CGFloat(row) * spacingY
+                let peg = SKShapeNode(circleOfRadius: 14)
+                peg.fillColor = .systemOrange
+                peg.strokeColor = .white
+                peg.position = CGPoint(x: x, y: y)
+                peg.physicsBody = SKPhysicsBody(circleOfRadius: 14)
+                peg.physicsBody?.isDynamic = false
+                peg.physicsBody?.restitution = 0.8
+                peg.physicsBody?.categoryBitMask = PhysicsCategory.pegs
+                peg.physicsBody?.contactTestBitMask = PhysicsCategory.projectiles
+                addChild(peg)
+            }
+        }
+    }
+
+    private func addSlots() {
+        let slotWidth = (size.width - 120) / 3
+        let slotHeight: CGFloat = 80
+        let slotValuesOrder = [10, 20, 50]
+        for index in 0..<3 {
+            let colors: [SKColor] = [.systemBlue, .systemPurple, .systemYellow]
+            let slot = SKSpriteNode(color: colors[index], size: CGSize(width: slotWidth - 10, height: slotHeight))
+            let x = CGFloat(index) * slotWidth + slotWidth / 2 + 60
+            slot.position = CGPoint(x: x, y: 80)
+            slot.physicsBody = SKPhysicsBody(rectangleOf: slot.size)
+            slot.physicsBody?.isDynamic = false
+            slot.physicsBody?.categoryBitMask = PhysicsCategory.slots
+            slot.physicsBody?.contactTestBitMask = PhysicsCategory.projectiles
+            slot.physicsBody?.collisionBitMask = PhysicsCategory.none
+            slotValues[slot] = slotValuesOrder[index]
+            addChild(slot)
+
+            let label = SKLabelNode(text: "\(slotValuesOrder[index])")
+            label.fontName = "AvenirNext-Bold"
+            label.fontColor = .black
+            label.fontSize = 22
+            label.position = CGPoint(x: 0, y: -10)
+            label.verticalAlignmentMode = .center
+            slot.addChild(label)
+        }
+
+        for index in 0...3 {
+            let guide = SKSpriteNode(color: .darkGray, size: CGSize(width: 4, height: 140))
+            let x = CGFloat(index) * ((size.width - 120) / 3) + 60
+            guide.position = CGPoint(x: x, y: 150)
+            guide.physicsBody = SKPhysicsBody(rectangleOf: guide.size)
+            guide.physicsBody?.isDynamic = false
+            guide.physicsBody?.categoryBitMask = PhysicsCategory.walls
+            guide.physicsBody?.collisionBitMask = PhysicsCategory.projectiles
+            guide.physicsBody?.contactTestBitMask = PhysicsCategory.none
+            addChild(guide)
+        }
+    }
+
+    private func spawnBall(at x: CGFloat) {
+        guard ballsDropped < maxBalls else { return }
+        let jitter = CGFloat.random(in: -12...12)
+        let clampedX = min(max(x + jitter, 60), size.width - 60)
+        let ball = SKShapeNode(circleOfRadius: 16)
+        ball.fillColor = .systemTeal
+        ball.strokeColor = .white
+        ball.position = CGPoint(x: clampedX, y: size.height - 80)
+        ball.zPosition = 5
+        let body = SKPhysicsBody(circleOfRadius: 16)
+        body.restitution = 0.75
+        body.friction = 0.1
+        body.linearDamping = 0.1
+        body.categoryBitMask = PhysicsCategory.projectiles
+        body.contactTestBitMask = PhysicsCategory.slots | PhysicsCategory.pegs | PhysicsCategory.walls
+        body.collisionBitMask = PhysicsCategory.pegs | PhysicsCategory.walls
+        ball.physicsBody = body
+        addChild(ball)
+        activeBalls.insert(ball)
+        ballsDropped += 1
+    }
+
+    private func updateTicketsLabel() {
+        hudTicketsLabel.text = "Tickets: \(TicketStore.tickets)"
+    }
+
+    private func showOverlay(with message: String) {
+        overlayNode.isHidden = false
+        overlayNode.alpha = 0
+        resultLabel.text = message
+        overlayNode.run(SKAction.fadeIn(withDuration: 0.25))
+    }
+
+    private func handleBackToPark() {
+        guard let view = view else { return }
+        let scene = ParkScene(size: size)
+        view.transition(to: scene)
+    }
+
+    private func handlePlayAgain() {
+        overlayNode.isHidden = true
+        overlayNode.alpha = 1
+        resultLabel.text = ""
+        ballsDropped = 0
+        for ball in activeBalls { ball.removeFromParent() }
+        activeBalls.removeAll()
+        playAgainButton.colorBlendFactor = 0
+        if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode {
+            backNode.colorBlendFactor = 0
+        }
+    }
+
+    private func handleSlotWin(value: Int, at position: CGPoint) {
+        TicketStore.addTickets(value)
+        updateTicketsLabel()
+
+        let label = SKLabelNode(text: "+\(value)")
+        label.fontName = "AvenirNext-Bold"
+        label.fontSize = 22
+        label.fontColor = .white
+        label.position = position
+        label.zPosition = 20
+        addChild(label)
+        let action = SKAction.sequence([
+            SKAction.moveBy(x: 0, y: 60, duration: 0.6),
+            SKAction.fadeOut(withDuration: 0.3),
+            SKAction.removeFromParent()
+        ])
+        label.run(action)
+    }
+
+    func didBegin(_ contact: SKPhysicsContact) {
+        let first = contact.bodyA.categoryBitMask
+        let second = contact.bodyB.categoryBitMask
+        if first == PhysicsCategory.slots && second == PhysicsCategory.projectiles {
+            handleBall(contact.bodyB.node, in: contact.bodyA.node)
+        } else if second == PhysicsCategory.slots && first == PhysicsCategory.projectiles {
+            handleBall(contact.bodyA.node, in: contact.bodyB.node)
+        }
+    }
+
+    private func handleBall(_ ballNode: SKNode?, in slotNode: SKNode?) {
+        guard let ball = ballNode, let slot = slotNode, let value = slotValues[slot] else { return }
+        if activeBalls.contains(ball) {
+            activeBalls.remove(ball)
+            ball.removeFromParent()
+            handleSlotWin(value: value, at: slot.position + CGPoint(x: 0, y: 50))
+            if ballsDropped >= maxBalls && activeBalls.isEmpty {
+                showOverlay(with: "All balls used!\nTap Play Again or Back")
+            }
+        }
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+
+        if !overlayNode.isHidden {
+            let location = touch.location(in: overlayNode)
+            if playAgainButton.contains(location) {
+                playAgainButton.colorBlendFactor = 0.4
+            } else if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode, backNode.contains(location) {
+                backNode.colorBlendFactor = 0.4
+            }
+            return
+        }
+
+        let cameraLocation = touch.location(in: camera ?? self)
+        if backButton.contains(cameraLocation) {
+            backButton.colorBlendFactor = 0.4
+            return
+        }
+
+        let location = touch.location(in: self)
+        spawnBall(at: location.x)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let touch = touches.first else { return }
+
+        if !overlayNode.isHidden {
+            let location = touch.location(in: overlayNode)
+            if playAgainButton.contains(location) {
+                playAgainButton.colorBlendFactor = 0
+                handlePlayAgain()
+                return
+            }
+            if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode, backNode.contains(location) {
+                backNode.colorBlendFactor = 0
+                handleBackToPark()
+                return
+            }
+            playAgainButton.colorBlendFactor = 0
+            if let backNode = overlayNode.childNode(withName: "overlayBack") as? ButtonNode {
+                backNode.colorBlendFactor = 0
+            }
+            return
+        }
+
+        let cameraLocation = touch.location(in: camera ?? self)
+        if backButton.contains(cameraLocation) {
+            backButton.colorBlendFactor = 0
+            handleBackToPark()
+            return
+        }
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        touchesEnded(touches, with: event)
+    }
+
+    override func update(_ currentTime: TimeInterval) {
+        var toRemove: [SKNode] = []
+        for ball in activeBalls where ball.position.y < 40 {
+            toRemove.append(ball)
+        }
+        for ball in toRemove {
+            activeBalls.remove(ball)
+            ball.removeFromParent()
+        }
+        if !overlayNode.isHidden { return }
+        if ballsDropped >= maxBalls && activeBalls.isEmpty {
+            showOverlay(with: "All balls used!\nTap Play Again or Back")
+        }
+    }
+}
+
+private extension CGPoint {
+    static func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+    }
+}

--- a/ThemeParkPlayground/Shared.swift
+++ b/ThemeParkPlayground/Shared.swift
@@ -1,0 +1,81 @@
+import SpriteKit
+
+struct PhysicsCategory {
+    static let none: UInt32 = 0
+    static let player: UInt32 = 1 << 0
+    static let walls: UInt32 = 1 << 1
+    static let ridePads: UInt32 = 1 << 2
+    static let portalPads: UInt32 = 1 << 3
+    static let projectiles: UInt32 = 1 << 4
+    static let bottles: UInt32 = 1 << 5
+    static let pegs: UInt32 = 1 << 6
+    static let slots: UInt32 = 1 << 7
+}
+
+enum Direction: CaseIterable {
+    case up, down, left, right
+
+    var vector: CGVector {
+        switch self {
+        case .up: return CGVector(dx: 0, dy: 1)
+        case .down: return CGVector(dx: 0, dy: -1)
+        case .left: return CGVector(dx: -1, dy: 0)
+        case .right: return CGVector(dx: 1, dy: 0)
+        }
+    }
+}
+
+struct TicketStore {
+    private static let key = "tickets"
+
+    static var tickets: Int {
+        get { UserDefaults.standard.integer(forKey: key) }
+        set { UserDefaults.standard.set(newValue, forKey: key) }
+    }
+
+    static func addTickets(_ amount: Int) {
+        tickets += amount
+    }
+}
+
+extension SKView {
+    func transition(to scene: SKScene, transition: SKTransition = .fade(withDuration: 0.5)) {
+        scene.scaleMode = .resizeFill
+        presentScene(scene, transition: transition)
+    }
+}
+
+extension SKNode {
+    func cameraShake(duration: TimeInterval = 0.4, amplitude: CGFloat = 12) {
+        guard let camera = scene?.camera else { return }
+        let numberOfShakes = Int(duration / 0.04)
+        var actions: [SKAction] = []
+        for _ in 0..<numberOfShakes {
+            let dx = CGFloat.random(in: -amplitude...amplitude)
+            let dy = CGFloat.random(in: -amplitude...amplitude)
+            actions.append(SKAction.moveBy(x: dx, y: dy, duration: 0.02))
+            actions.append(SKAction.moveBy(x: -dx, y: -dy, duration: 0.02))
+        }
+        camera.run(SKAction.sequence(actions))
+    }
+}
+
+class ButtonNode: SKSpriteNode {
+    var action: (() -> Void)?
+
+    init(size: CGSize, text: String, color: SKColor) {
+        super.init(texture: nil, color: color, size: size)
+        isUserInteractionEnabled = false
+        let label = SKLabelNode(text: text)
+        label.fontName = "AvenirNext-Bold"
+        label.fontSize = 18
+        label.verticalAlignmentMode = .center
+        label.horizontalAlignmentMode = .center
+        label.fontColor = .white
+        addChild(label)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal SpriteKit app entry point with `AppDelegate` and `GameViewController`
- implement `MainMenuScene` and hub-style `ParkScene` with camera-follow, D-pad movement, keyboard support, and mini-game portals
- build Bottle Toss and Plinko mini-game scenes with ticket rewards, HUDs, and reset overlays plus shared physics/ticket utilities

## Testing
- not run (iOS project scaffold)


------
https://chatgpt.com/codex/tasks/task_e_68e5d3ca0b28832b83bce66fc52d8a90